### PR TITLE
Properly fix the contest cloning bug (#3)

### DIFF
--- a/judge/views/contests.py
+++ b/judge/views/contests.py
@@ -374,11 +374,12 @@ class ContestClone(ContestMixin, PermissionRequiredMixin, TitleMixin, SingleObje
     def form_valid(self, form):
         contest = self.object
 
-        tags = contest.tags.all()
-        organizations = contest.organizations.all()
-        private_contestants = contest.private_contestants.all()
-        view_contest_scoreboard = contest.view_contest_scoreboard.all()
-        contest_problems = ContestProblem.objects.filter(contest=contest)
+        # Using list() to force QuerySets evaluation, as `contest.pk = None` affects these queries
+        tags = list(contest.tags.all())
+        organizations = list(contest.organizations.all())
+        private_contestants = list(contest.private_contestants.all())
+        view_contest_scoreboard = list(contest.view_contest_scoreboard.all())
+        contest_problems = list(contest.contest_problems.all())
         old_key = contest.key
 
         contest.pk = None


### PR DESCRIPTION
# Description

As per the Django docs, QuerySets are evaluated lazily. This is crucial, as the assignment of pk to None affects QuerySets that haven't been evaluated yet (not sure if these behaviors are intended). Using list() effectively forces the evaluation.

## Why

Why this PR is needed?

Fixes #3 

# How Has This Been Tested?

Tested on my local

# Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have explained the purpose of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the README/documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Informed of breaking changes, testing and migrations (if applicable).
- [ ] Attached screenshots (if applicable).

By submitting this pull request, I confirm that my contribution is made under the terms of the AGPL-3.0 License.
